### PR TITLE
Order snapshot range data by date

### DIFF
--- a/app/controllers/api/v1/ranges_controller.rb
+++ b/app/controllers/api/v1/ranges_controller.rb
@@ -8,7 +8,7 @@ module Api
         start_date = DateTime.parse(params[:start_date].to_s)
         end_date = DateTime.parse(params[:end_date].to_s)
 
-        snapshots_in_range = WeatherSnapshot.where(dateutc: start_date..end_date)
+        snapshots_in_range = WeatherSnapshot.where(dateutc: start_date..end_date).order(:dateutc)
         puts "Snapshots in range #{snapshots_in_range.size}"
         render json: snapshots_in_range
       end


### PR DESCRIPTION
Have the db query sort the returned data by timestamp so that the client doesn't get confused.